### PR TITLE
refactor: Use chain created_at as updated_at in API responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,21 @@ postgres: ## Start a postgres container with high connections for testing purpos
       -d postgres \
       postgres -N 1000
 
-.PHONY: psql ## Connect to the test postgres container
-psql:
+.PHONY: psql
+psql: ## Connect to the test postgres container
 	psql -h localhost -U postgres -d chain_registry
 
 .PHONY: prepare
 prepare: ## Prepare sqlx offline data
 	cargo sqlx prepare -- --tests
+
+.PHONY: test
+test: prepare ## Run unit and quick integration tests
+	cargo test
+
+.PHONY: test-all
+test-all: prepare ## Run all tests including longer integration tests
+	cargo test -- --include-ignored
 
 .PHONY: watch
 watch: prepare ## Watch for changes and run cargo

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -84,6 +84,45 @@
     },
     "query": "\n        INSERT INTO chain (name, network, chain_data, asset_data, commit)\n        VALUES ($1, $2, $3, $4, $5)\n        ON CONFLICT (name, network, commit) DO UPDATE SET commit = $5\n        RETURNING id\n        "
   },
+  "44917f43077160c7f01a1f11dc5c667367e6513b4d13adad994e12aceb8c3021": {
+    "describe": {
+      "columns": [
+        {
+          "name": "commit",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 1,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "chain_data",
+          "ordinal": 2,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "asset_data",
+          "ordinal": 3,
+          "type_info": "Jsonb"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text"
+        ]
+      }
+    },
+    "query": "\n        SELECT commit, created_at, chain_data, asset_data FROM chain WHERE name = $1 AND network = $2 ORDER BY created_at DESC LIMIT 1\n        "
+  },
   "76cefcbc3eb07498d84cdd4a54fcb84c8344088059765db79f2af9981a4536d2": {
     "describe": {
       "columns": [],
@@ -210,45 +249,6 @@
       }
     },
     "query": "SELECT commit FROM chain"
-  },
-  "e928fccca7301afed532322b81cd6b7f6357a652311f8119aa56f0a5336fa21e": {
-    "describe": {
-      "columns": [
-        {
-          "name": "commit",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "updated_at",
-          "ordinal": 1,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "chain_data",
-          "ordinal": 2,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "asset_data",
-          "ordinal": 3,
-          "type_info": "Jsonb"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "\n        SELECT commit, updated_at, chain_data, asset_data FROM chain WHERE name = $1 AND network = $2 ORDER BY created_at DESC LIMIT 1\n        "
   },
   "edf2e69e5a87eb580c15ee584b1e14bccc4d3e24ebbd914888c52ad8d34f6bc3": {
     "describe": {

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -123,6 +123,38 @@
     },
     "query": "\n        SELECT commit, created_at, chain_data, asset_data FROM chain WHERE name = $1 AND network = $2 ORDER BY created_at DESC LIMIT 1\n        "
   },
+  "63ab69fc3cb2588be44f910bee73e317ff9e2979210c17499bfd2593ececf00e": {
+    "describe": {
+      "columns": [
+        {
+          "name": "commit",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "names",
+          "ordinal": 1,
+          "type_info": "TextArray"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "\n        SELECT commit, \n        array_agg(name order by name) as names, \n        MAX(created_at) as created_at \n        FROM chain WHERE network = $1 GROUP BY commit ORDER BY MAX(created_at) DESC LIMIT 1;\n        "
+  },
   "76cefcbc3eb07498d84cdd4a54fcb84c8344088059765db79f2af9981a4536d2": {
     "describe": {
       "columns": [],
@@ -169,38 +201,6 @@
       }
     },
     "query": "SELECT chain_data->>'chain_id' as chain_id FROM chain WHERE id = $1"
-  },
-  "acf87b87f0f471c98f360d2c69de3da1b39a4a641c730945f230a74027afabca": {
-    "describe": {
-      "columns": [
-        {
-          "name": "commit",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "names",
-          "ordinal": 1,
-          "type_info": "TextArray"
-        },
-        {
-          "name": "updated_at",
-          "ordinal": 2,
-          "type_info": "Timestamptz"
-        }
-      ],
-      "nullable": [
-        false,
-        null,
-        null
-      ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      }
-    },
-    "query": "\n        SELECT commit, \n        array_agg(name order by name) as names, \n        MAX(updated_at) as updated_at \n        FROM chain WHERE network = $1 GROUP BY commit ORDER BY MAX(created_at) DESC LIMIT 1;\n        "
   },
   "b89c3da5d70c26aa741c3a51f08ab7f6c743d29086ea2b51368d9718569d8f5f": {
     "describe": {

--- a/src/api/chain.rs
+++ b/src/api/chain.rs
@@ -35,7 +35,7 @@ pub async fn get_chain_data(
     let resp = APIResponse {
         meta: Meta {
             commit: chain.commit,
-            updated_at: chain.updated_at,
+            updated_at: chain.created_at,
         },
         result: chain.chain_data,
     };
@@ -73,7 +73,7 @@ pub async fn get_chain_asset_list(
     let resp = APIResponse {
         meta: Meta {
             commit: chain.commit,
-            updated_at: chain.updated_at,
+            updated_at: chain.created_at,
         },
         result: chain.asset_data,
     };

--- a/src/api/chain.rs
+++ b/src/api/chain.rs
@@ -127,7 +127,7 @@ pub async fn list_chains(
     let resp = ChainList {
         meta: Meta {
             commit: list.commit,
-            updated_at: list.updated_at,
+            updated_at: list.created_at,
         },
         result: chain_list,
     };

--- a/src/db/chain.rs
+++ b/src/db/chain.rs
@@ -54,7 +54,7 @@ pub async fn insert_chain(
 #[derive(Debug, Clone)]
 pub struct Chain {
     pub commit: String,
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
     pub chain_data: JsonValue,
     pub asset_data: JsonValue,
 }
@@ -67,7 +67,7 @@ pub async fn find_chain(
     sqlx::query_as!(
         Chain,
         r#"
-        SELECT commit, updated_at, chain_data, asset_data FROM chain WHERE name = $1 AND network = $2 ORDER BY created_at DESC LIMIT 1
+        SELECT commit, created_at, chain_data, asset_data FROM chain WHERE name = $1 AND network = $2 ORDER BY created_at DESC LIMIT 1
         "#,
         chain_name,
         network,

--- a/src/db/chain.rs
+++ b/src/db/chain.rs
@@ -97,7 +97,7 @@ pub async fn truncate_old_chains(executor: impl PgExecutor<'_>, keep: i64) -> sq
 #[derive(Debug)]
 pub struct ChainList {
     pub commit: String,
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
     pub names: Vec<String>,
 }
 
@@ -106,7 +106,7 @@ pub async fn list_chains(executor: impl PgExecutor<'_>, network: &str) -> sqlx::
         r#"
         SELECT commit, 
         array_agg(name order by name) as names, 
-        MAX(updated_at) as updated_at 
+        MAX(created_at) as created_at 
         FROM chain WHERE network = $1 GROUP BY commit ORDER BY MAX(created_at) DESC LIMIT 1;
         "#,
         network,
@@ -116,7 +116,7 @@ pub async fn list_chains(executor: impl PgExecutor<'_>, network: &str) -> sqlx::
 
     Ok(ChainList {
         commit: row.commit,
-        updated_at: row.updated_at.unwrap_or(chrono::Utc::now()),
+        created_at: row.created_at.unwrap_or(chrono::Utc::now()),
         names: row.names.unwrap_or(vec![]),
     })
 }

--- a/src/hydrate.rs
+++ b/src/hydrate.rs
@@ -81,6 +81,7 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    #[ignore] // Longer integration test
     fn test_shallow_clone() {
         let temp_dir = TempDir::new().unwrap();
 


### PR DESCRIPTION
It more closely matches the git commit date. 

Therefore, looking at a chain's response like GET `v1/mainnet/chains` the `meta.updated_at` will give more accurate information as to when the entry was updated from the source (i.e. the chain registry repo).

Not a perfect solution given it depends on when we poll GitHub and insert new chain data. A more accurate solution may be using the date as present in the git history. 